### PR TITLE
解决厂商推送只能传String问题，GroupPush解析返回参数报错问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@
 ## 安装
 
 ### maven 方式
-将下边的依赖条件放到你项目的 maven pom.xml 文件里。v3.3.10 为例，最新版本请看[Release页面](https://github.com/jpush/jpush-api-java-client/releases)
+将下边的依赖条件放到你项目的 maven pom.xml 文件里。v3.4.6 为例，最新版本请看[Release页面](https://github.com/jpush/jpush-api-java-client/releases)
 
 ```Java
 <dependency>
     <groupId>cn.jpush.api</groupId>
     <artifactId>jpush-client</artifactId>
-    <version>3.3.10</version>
+    <version>3.4.6</version>
 </dependency>
 ```
 ### jar 包方式
@@ -45,7 +45,7 @@
     <dependency>
         <groupId>cn.jpush.api</groupId>
         <artifactId>jiguang-common</artifactId>
-        <version>1.1.4</version>
+        <version>1.1.8</version>
     </dependency>
     <dependency>
         <groupId>io.netty</groupId>

--- a/example/main/java/cn/jpush/api/examples/PushExample.java
+++ b/example/main/java/cn/jpush/api/examples/PushExample.java
@@ -10,6 +10,7 @@ import cn.jiguang.common.resp.ResponseWrapper;
 import cn.jpush.api.JPushClient;
 import cn.jpush.api.push.CIDResult;
 import cn.jpush.api.push.GroupPushClient;
+import cn.jpush.api.push.GroupPushResult;
 import cn.jpush.api.push.PushResult;
 import cn.jpush.api.push.model.*;
 import cn.jpush.api.push.model.audience.Audience;
@@ -227,7 +228,8 @@ public class PushExample {
         GroupPushClient groupPushClient = new GroupPushClient(GROUP_MASTER_SECRET, GROUP_PUSH_KEY);
         final PushPayload payload = buildPushObject_android_and_ios();
         try {
-            Map<String, PushResult> result = groupPushClient.sendGroupPush(payload);
+            GroupPushResult groupPushResult = groupPushClient.sendGroupPush(payload);
+            Map<String, PushResult> result = groupPushResult.getAppResultMap();
             for (Map.Entry<String, PushResult> entry : result.entrySet()) {
                 PushResult pushResult = entry.getValue();
                 PushResult.Error error = pushResult.error;

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>cn.jpush.api</groupId>
 	<artifactId>jpush-client</artifactId>
-	<version>3.4.6-SNAPSHOT</version>
+	<version>3.4.7-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<url>https://github.com/jpush/jpush-api-java-client</url>
 	<name>JPush API Java Client</name>

--- a/src/main/java/cn/jpush/api/push/GroupPushResult.java
+++ b/src/main/java/cn/jpush/api/push/GroupPushResult.java
@@ -1,0 +1,38 @@
+package cn.jpush.api.push;
+
+import java.util.Map;
+
+/**
+ * @author tp
+ * @since 2020/8/6
+ */
+public class GroupPushResult {
+
+    private Map<String, PushResult> appResultMap;
+
+    private String groupMsgId;
+
+    public GroupPushResult() {
+    }
+
+    public GroupPushResult(String groupMsgId, Map<String, PushResult> appResultMap) {
+        this.groupMsgId = groupMsgId;
+        this.appResultMap = appResultMap;
+    }
+
+    public Map<String, PushResult> getAppResultMap() {
+        return appResultMap;
+    }
+
+    public void setAppResultMap(Map<String, PushResult> appResultMap) {
+        this.appResultMap = appResultMap;
+    }
+
+    public String getGroupMsgId() {
+        return groupMsgId;
+    }
+
+    public void setGroupMsgId(String groupMsgId) {
+        this.groupMsgId = groupMsgId;
+    }
+}

--- a/src/main/java/cn/jpush/api/push/model/PushPayload.java
+++ b/src/main/java/cn/jpush/api/push/model/PushPayload.java
@@ -169,6 +169,10 @@ public class PushPayload implements PushModel {
     public Audience getAudience() {
         return audience;
     }
+
+    public Options getOptions() {
+        return options;
+    }
     
     @Override
     public JsonElement toJSON() {

--- a/src/test/java/cn/jpush/api/push/GroupPushClientTest.java
+++ b/src/test/java/cn/jpush/api/push/GroupPushClientTest.java
@@ -24,7 +24,8 @@ public class GroupPushClientTest extends BaseTest {
         GroupPushClient groupPushClient = new GroupPushClient(GROUP_MASTER_SECRET, GROUP_PUSH_KEY);
         final PushPayload payload = buildPushObject_android();
         try {
-            Map<String, PushResult> result = groupPushClient.sendGroupPush(payload);
+            GroupPushResult groupPushresult = groupPushClient.sendGroupPush(payload);
+            Map<String, PushResult> result = groupPushresult.getAppResultMap();
             for (Map.Entry<String, PushResult> entry : result.entrySet()) {
                 PushResult pushResult = entry.getValue();
                 PushResult.Error error = pushResult.error;

--- a/src/test/java/cn/jpush/api/push/model/OptionsTest.java
+++ b/src/test/java/cn/jpush/api/push/model/OptionsTest.java
@@ -13,6 +13,9 @@ import com.google.gson.JsonPrimitive;
 import cn.jiguang.common.ServiceHelper;
 import cn.jpush.api.FastTests;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Category(FastTests.class)
 public class OptionsTest {
 
@@ -126,6 +129,62 @@ public class OptionsTest {
         json.add("big_push_duration", new JsonPrimitive(10));
         json.add("apns_production", new JsonPrimitive(false));
         
+        assertThat(options.toJSON(), is((JsonElement) json));
+    }
+
+    @Test
+    public void testThirdPartyChannel() {
+        int sendno = ServiceHelper.generateSendno();
+
+        Map<String, Map<String, String>> thirdMap = new HashMap<>();
+        Map<String, String> huaweiMap = new HashMap<>();
+        huaweiMap.put("distribution", "jpush");
+        thirdMap.put("huawei", huaweiMap);
+
+        Options options = Options.newBuilder()
+                .setSendno(sendno)
+                .setThirdPartyChannel(thirdMap)
+                .build();
+        System.out.println("json string: " + options.toJSON());
+
+        JsonObject json = new JsonObject();
+        JsonObject thirdPartyChannel = new JsonObject();
+        JsonObject huawei = new JsonObject();
+        huawei.addProperty("distribution", "jpush");
+        thirdPartyChannel.add("huawei", huawei);
+        json.add("sendno", new JsonPrimitive(sendno));
+        json.add("apns_production", new JsonPrimitive(false));
+        json.add("third_party_channel", thirdPartyChannel);
+
+        assertThat(options.toJSON(), is((JsonElement) json));
+    }
+
+    @Test
+    public void testThirdPartyChannelV2() {
+        int sendno = ServiceHelper.generateSendno();
+
+        Map<String, JsonObject> thirdMap = new HashMap<>();
+        JsonObject vivoJsonObj = new JsonObject();
+        vivoJsonObj.addProperty("distribution", "ospush");
+        vivoJsonObj.addProperty("classification", 1);
+        thirdMap.put("vivo", vivoJsonObj);
+
+        Options options = Options.newBuilder()
+                .setSendno(sendno)
+                .setThirdPartyChannelV2(thirdMap)
+                .build();
+        System.out.println("json string: " + options.toJSON());
+
+        JsonObject json = new JsonObject();
+        JsonObject thirdPartyChannel = new JsonObject();
+        JsonObject vivo = new JsonObject();
+        vivo.addProperty("distribution", "ospush");
+        vivo.addProperty("classification", 1);
+        thirdPartyChannel.add("vivo", vivo);
+        json.add("sendno", new JsonPrimitive(sendno));
+        json.add("apns_production", new JsonPrimitive(false));
+        json.add("third_party_channel", thirdPartyChannel);
+
         assertThat(options.toJSON(), is((JsonElement) json));
     }
 }


### PR DESCRIPTION
1. 增对Options构造时setThirdPartyChannelV2方法，现在提交第三方厂商时支持任意类型。
2. GroupPushClient#sendGroupPush新增了对group_msgid字段的处理。